### PR TITLE
添加了TextToCode字典，完善了'全部'字段的支持

### DIFF
--- a/dist/app.js
+++ b/dist/app.js
@@ -14,6 +14,7 @@ var _chinaAreaData2 = _interopRequireDefault(_chinaAreaData);
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 var CodeToText = {};
+var TextToCode = {};
 // 深拷贝数组
 var cloneArray = function cloneArray(obj) {
   var newArray = [];
@@ -33,11 +34,15 @@ for (var prop in _chinaAreaData2.default[rootCode]) {
     label: _chinaAreaData2.default[rootCode][prop]
   });
   CodeToText[prop] = _chinaAreaData2.default[rootCode][prop];
+  TextToCode[_chinaAreaData2.default[rootCode][prop]] = {
+    code: prop
+  };
 }
 
 // 计算市
 for (var i = 0; i < regionData.length; i++) {
   var provinceCode = regionData[i].value;
+  var provinceText = regionData[i].label;
   var provinceChildren = [];
   for (var _prop in _chinaAreaData2.default[provinceCode]) {
     provinceChildren.push({
@@ -45,20 +50,25 @@ for (var i = 0; i < regionData.length; i++) {
       label: _chinaAreaData2.default[provinceCode][_prop]
     });
     CodeToText[_prop] = _chinaAreaData2.default[provinceCode][_prop];
+    TextToCode[provinceText][_chinaAreaData2.default[provinceCode][_prop]] = {
+      code: _prop
+    };
   }
   if (provinceChildren.length) {
     regionData[i].children = provinceChildren;
   }
 }
 
-exports.provinceAndCityData = provinceAndCityData = cloneArray(regionData);
+exports.provinceAndCityData = provinceAndCityData = cloneArray(regionData
 
 // 计算区
-for (var _i = 0; _i < regionData.length; _i++) {
+);for (var _i = 0; _i < regionData.length; _i++) {
   var province = regionData[_i].children;
+  var _provinceText = regionData[_i].label;
   if (province) {
     for (var j = 0; j < province.length; j++) {
       var cityCode = province[j].value;
+      var cityText = province[j].label;
       var cityChildren = [];
       for (var _prop2 in _chinaAreaData2.default[cityCode]) {
         cityChildren.push({
@@ -66,6 +76,9 @@ for (var _i = 0; _i < regionData.length; _i++) {
           label: _chinaAreaData2.default[cityCode][_prop2]
         });
         CodeToText[_prop2] = _chinaAreaData2.default[cityCode][_prop2];
+        TextToCode[_provinceText][cityText] = {
+          code: _prop2
+        };
       }
       if (cityChildren.length) {
         province[j].children = cityChildren;
@@ -73,6 +86,9 @@ for (var _i = 0; _i < regionData.length; _i++) {
     }
   }
 }
+
+//TODO: for DEBUG
+console.log(TextToCode);
 
 // 添加“全部”选项
 var provinceAndCityDataPlus = cloneArray(provinceAndCityData);

--- a/dist/app.js
+++ b/dist/app.js
@@ -27,6 +27,9 @@ var cloneArray = function cloneArray(obj) {
 var rootCode = '86';
 var regionData = [];
 var provinceAndCityData = [];
+
+CodeToText[''] = '全部';
+
 // 计算省
 for (var prop in _chinaAreaData2.default[rootCode]) {
   regionData.push({
@@ -36,6 +39,9 @@ for (var prop in _chinaAreaData2.default[rootCode]) {
   CodeToText[prop] = _chinaAreaData2.default[rootCode][prop];
   TextToCode[_chinaAreaData2.default[rootCode][prop]] = {
     code: prop
+  };
+  TextToCode[_chinaAreaData2.default[rootCode][prop]]['全部'] = {
+    code: ''
   };
 }
 
@@ -52,6 +58,9 @@ for (var i = 0; i < regionData.length; i++) {
     CodeToText[_prop] = _chinaAreaData2.default[provinceCode][_prop];
     TextToCode[provinceText][_chinaAreaData2.default[provinceCode][_prop]] = {
       code: _prop
+    };
+    TextToCode[provinceText][_chinaAreaData2.default[provinceCode][_prop]]['全部'] = {
+      code: ''
     };
   }
   if (provinceChildren.length) {

--- a/dist/app.js
+++ b/dist/app.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.CodeToText = exports.regionDataPlus = exports.provinceAndCityDataPlus = exports.regionData = exports.provinceAndCityData = undefined;
+exports.TextToCode = exports.CodeToText = exports.regionDataPlus = exports.provinceAndCityDataPlus = exports.regionData = exports.provinceAndCityData = undefined;
 
 var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
@@ -85,7 +85,7 @@ exports.provinceAndCityData = provinceAndCityData = cloneArray(regionData
           label: _chinaAreaData2.default[cityCode][_prop2]
         });
         CodeToText[_prop2] = _chinaAreaData2.default[cityCode][_prop2];
-        TextToCode[_provinceText][cityText] = {
+        TextToCode[_provinceText][cityText][_chinaAreaData2.default[cityCode][_prop2]] = {
           code: _prop2
         };
       }
@@ -95,9 +95,6 @@ exports.provinceAndCityData = provinceAndCityData = cloneArray(regionData
     }
   }
 }
-
-//TODO: for DEBUG
-console.log(TextToCode);
 
 // 添加“全部”选项
 var provinceAndCityDataPlus = cloneArray(provinceAndCityData);
@@ -154,3 +151,4 @@ exports.regionData = regionData;
 exports.provinceAndCityDataPlus = provinceAndCityDataPlus;
 exports.regionDataPlus = regionDataPlus;
 exports.CodeToText = CodeToText;
+exports.TextToCode = TextToCode;

--- a/src/App.vue
+++ b/src/App.vue
@@ -12,6 +12,7 @@
     <div class="bind">
       <div>绑定值：{{selectedOptions1}}</div>
       <div>区域码转汉字：{{CodeToText[selectedOptions1[0]]}},{{CodeToText[selectedOptions1[1]]}}</div>
+      <div>汉字转区域码：{{convertTextToCode(CodeToText[selectedOptions1[0]], CodeToText[selectedOptions1[1]])}}</div>
     </div>
     <div class="three">
       二级联动(带有“全部”选项)
@@ -25,6 +26,7 @@
     <div class="bind">
       <div>绑定值：{{selectedOptions3}}</div>
       <div>区域码转汉字：{{CodeToText[selectedOptions3[0]]}},{{CodeToText[selectedOptions3[1]]}}</div>
+      <div>汉字转区域码：{{convertTextToCode(CodeToText[selectedOptions3[0]], CodeToText[selectedOptions3[1]])}}</div>
     </div>
     <div class="three">
       三级联动（不带“全部”选项）
@@ -39,6 +41,7 @@
     <div class="bind">
       <div>绑定值：{{selectedOptions2}}</div>
       <div>区域码转汉字：{{CodeToText[selectedOptions2[0]]}},{{CodeToText[selectedOptions2[1]]}},{{CodeToText[selectedOptions2[2]]}}</div>
+      <div>汉字转区域码：{{convertTextToCode(CodeToText[selectedOptions2[0]], CodeToText[selectedOptions2[1]], CodeToText[selectedOptions2[2]])}}</div>
     </div>
     <div class="three">
       三级联动(带"全部选项")
@@ -53,17 +56,20 @@
     <div class="bind">
       <div>绑定值：{{selectedOptions4}}</div>
       <div>区域码转汉字：{{CodeToText[selectedOptions4[0]]}},{{CodeToText[selectedOptions4[1]]}},{{CodeToText[selectedOptions4[2]]}}</div>
+      <div>汉字转区域码：{{convertTextToCode(CodeToText[selectedOptions4[0]], CodeToText[selectedOptions4[1]], CodeToText[selectedOptions4[2]])}}</div>
+    </div>
     </div>
   </div>
 </template>
 
 <script>
-  import { provinceAndCityData, regionData, provinceAndCityDataPlus, regionDataPlus, CodeToText } from '../dist/app.js'
+  import { provinceAndCityData, regionData, provinceAndCityDataPlus, regionDataPlus, CodeToText, TextToCode } from '../dist/app.js'
 
   export default {
     data () {
       return {
         CodeToText: CodeToText,
+        TextToCode: TextToCode,
         BeiJing: CodeToText['110000'],
         provinceAndCityData: provinceAndCityData,
         provinceAndCityDataPlus: provinceAndCityDataPlus,
@@ -79,6 +85,21 @@
     methods: {
       handleChange (value) {
         console.log(value)
+      },
+      convertTextToCode(provinceText, cityText, regionText){
+        let code='';
+        if(provinceText && this.TextToCode[provinceText]){
+          let province=this.TextToCode[provinceText];
+          code+=province.code+', ';
+          if (cityText && province[cityText]) {
+            let city=province[cityText]
+            code+=city.code+', ';
+            if (regionText && city[regionText]) {
+              code+=city[regionText].code;
+            }
+          }
+        }
+        return code;
       }
     },
 

--- a/src/app.js
+++ b/src/app.js
@@ -14,6 +14,10 @@ const cloneArray = function (obj) {
 const rootCode = '86'
 const regionData = []
 let provinceAndCityData = []
+
+
+CodeToText[''] = '全部'
+
 // 计算省
 for (const prop in REGION_DATA[rootCode]) {
   regionData.push({
@@ -23,6 +27,9 @@ for (const prop in REGION_DATA[rootCode]) {
   CodeToText[prop] = REGION_DATA[rootCode][prop]
   TextToCode[REGION_DATA[rootCode][prop]] = {
     code: prop
+  }
+  TextToCode[REGION_DATA[rootCode][prop]]['全部'] = {
+    code: ''
   }
 }
 
@@ -39,6 +46,9 @@ for (let i = 0; i < regionData.length; i++) {
     CodeToText[prop] = REGION_DATA[provinceCode][prop]
     TextToCode[provinceText][REGION_DATA[provinceCode][prop]]={
       code: prop
+    }
+    TextToCode[provinceText][REGION_DATA[provinceCode][prop]]['全部'] = {
+      code: ''
     }
   }
   if (provinceChildren.length) {
@@ -73,7 +83,6 @@ for (let i = 0; i < regionData.length; i++) {
     }
   }
 }
-
 
 
 // 添加“全部”选项

--- a/src/app.js
+++ b/src/app.js
@@ -44,7 +44,7 @@ for (let i = 0; i < regionData.length; i++) {
       label: REGION_DATA[provinceCode][prop]
     })
     CodeToText[prop] = REGION_DATA[provinceCode][prop]
-    TextToCode[provinceText][REGION_DATA[provinceCode][prop]]={
+    TextToCode[provinceText][REGION_DATA[provinceCode][prop]] = {
       code: prop
     }
     TextToCode[provinceText][REGION_DATA[provinceCode][prop]]['全部'] = {
@@ -73,7 +73,7 @@ for (let i = 0; i < regionData.length; i++) {
           label: REGION_DATA[cityCode][prop]
         })
         CodeToText[prop] = REGION_DATA[cityCode][prop]
-        TextToCode[provinceText][cityText] = {
+        TextToCode[provinceText][cityText][REGION_DATA[cityCode][prop]] = {
           code: prop
         }
       }
@@ -135,4 +135,4 @@ for (let i = 0; i < regionDataPlus.length; i++) {
     }
   }
 }
-export { provinceAndCityData, regionData, provinceAndCityDataPlus, regionDataPlus, CodeToText }
+export { provinceAndCityData, regionData, provinceAndCityDataPlus, regionDataPlus, CodeToText, TextToCode }

--- a/src/app.js
+++ b/src/app.js
@@ -1,5 +1,6 @@
 import REGION_DATA from 'china-area-data'
 const CodeToText = {}
+const TextToCode = {}
 // 深拷贝数组
 const cloneArray = function (obj) {
   const newArray = []
@@ -20,11 +21,15 @@ for (const prop in REGION_DATA[rootCode]) {
     label: REGION_DATA[rootCode][prop]
   })
   CodeToText[prop] = REGION_DATA[rootCode][prop]
+  TextToCode[REGION_DATA[rootCode][prop]] = {
+    code: prop
+  }
 }
 
 // 计算市
 for (let i = 0; i < regionData.length; i++) {
   const provinceCode = regionData[i].value
+  const provinceText = regionData[i].label
   const provinceChildren = []
   for (const prop in REGION_DATA[provinceCode]) {
     provinceChildren.push({
@@ -32,6 +37,9 @@ for (let i = 0; i < regionData.length; i++) {
       label: REGION_DATA[provinceCode][prop]
     })
     CodeToText[prop] = REGION_DATA[provinceCode][prop]
+    TextToCode[provinceText][REGION_DATA[provinceCode][prop]]={
+      code: prop
+    }
   }
   if (provinceChildren.length) {
     regionData[i].children = provinceChildren
@@ -43,9 +51,11 @@ provinceAndCityData = cloneArray(regionData)
 // 计算区
 for (let i = 0; i < regionData.length; i++) {
   const province = regionData[i].children
+  const provinceText = regionData[i].label
   if (province) {
     for (let j = 0; j < province.length; j++) {
       const cityCode = province[j].value
+      const cityText = province[j].label
       const cityChildren = []
       for (const prop in REGION_DATA[cityCode]) {
         cityChildren.push({
@@ -53,6 +63,9 @@ for (let i = 0; i < regionData.length; i++) {
           label: REGION_DATA[cityCode][prop]
         })
         CodeToText[prop] = REGION_DATA[cityCode][prop]
+        TextToCode[provinceText][cityText] = {
+          code: prop
+        }
       }
       if (cityChildren.length) {
         province[j].children = cityChildren
@@ -60,6 +73,8 @@ for (let i = 0; i < regionData.length; i++) {
     }
   }
 }
+
+
 
 // 添加“全部”选项
 const provinceAndCityDataPlus = cloneArray(provinceAndCityData)


### PR DESCRIPTION
1. 添加了`TextToCode`字典，使用方法为`TextToCode[provinceText].code`或者`TextToCode[provinceText][cityText].code`或者`TextToCode[provinceText][cityText][regionText].code`。
2. 在`TextToCode`和`CodeToText`这两个字典中都加入了`全部`字段
3. 相应的更新了demo，可以看到`区域码转汉字`这一栏现在可以正常解析出`全部`了